### PR TITLE
Fix: Adapt comment for longer texts

### DIFF
--- a/src/main/web/src/organisms/comment/Comment.css
+++ b/src/main/web/src/organisms/comment/Comment.css
@@ -1,7 +1,6 @@
 .comment {
   background-color: var(--component-grey);
   border-radius: var(--border-radius);
-  height: auto;
   margin-top: 10px;
   margin-left: 20px;
   margin-right: 20px;
@@ -22,10 +21,9 @@
 }
 
 .comment-text {
-  position: absolute;
-  top: 20px;
-  left: 18%;
-  width: 60%;
+  position: relative;
+  left: 20px;
+  width: 800px;
   font-size: var(--headline-font-size);
   font-weight: var(--normal-font-weight);
 }

--- a/src/main/web/src/organisms/comment/Comment.css
+++ b/src/main/web/src/organisms/comment/Comment.css
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: row;
   gap: 20px;
+  align-items: center;
 }
 
 .comment-text, .comment-author-date {

--- a/src/main/web/src/organisms/comment/Comment.tsx
+++ b/src/main/web/src/organisms/comment/Comment.tsx
@@ -116,9 +116,7 @@ export const Comment: React.FC<CommentProps> = (props: CommentProps) => {
             </Link>
             <div className="comment-author-date">{formattedTime}</div>
           </div>
-          <div className="comment-text-wrapper">
-            <div className="comment-text">{text}</div>
-          </div>
+          <div className="comment-text">{text}</div>
         </div>
 
         <div className="comment-interaction">

--- a/src/main/web/src/organisms/comment/Comment.tsx
+++ b/src/main/web/src/organisms/comment/Comment.tsx
@@ -90,12 +90,12 @@ export const Comment: React.FC<CommentProps> = (props: CommentProps) => {
       }
     };
     document.addEventListener('keydown', handleEsc);
-    return () => {
+    return (): void => {
       document.removeEventListener('keydown', handleEsc);
     };
   }, [reportOpen, handleClose]);
 
-  useEffect(() => {
+  useEffect((): void => {
     const fetchUserId = async () => {
       const id = await getUserIdByAccountId(accountId);
       setUserId(id);
@@ -116,7 +116,9 @@ export const Comment: React.FC<CommentProps> = (props: CommentProps) => {
             </Link>
             <div className="comment-author-date">{formattedTime}</div>
           </div>
-          <div className="comment-text">{text}</div>
+          <div className="comment-text-wrapper">
+            <div className="comment-text">{text}</div>
+          </div>
         </div>
 
         <div className="comment-interaction">


### PR DESCRIPTION
Before:
![image](https://github.com/SE-TINF22B6/DHBWhub/assets/111356450/493cf132-4aa2-4ce9-a941-f0a0fb0532f7)
After:
![image](https://github.com/SE-TINF22B6/DHBWhub/assets/111356450/bfd7e538-69fe-4174-84f5-a343409331f4)
